### PR TITLE
Support reading and writing `Point`, `LineString` etc. directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub trait WKBSerializable {
 /// assert_eq!(p2, Point::new(2., 4.));
 /// # }
 /// ```
-pub trait WKBUnserializable {
+pub trait WKBDeserializable {
     /// Attempt to read an instance of self from this `Read`.
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError> where Self: Sized;
 }
@@ -186,9 +186,9 @@ pub trait WKBUnserializable {
 /// //assert_eq!(bytes, vec![1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 16, 64]);
 /// # }
 /// ```
-pub trait WKBAbleExt: WKBSerializable + WKBUnserializable {}
+pub trait WKBAbleExt: WKBSerializable + WKBDeserializable {}
 
-impl<T> WKBAbleExt for T where T: ?Sized + WKBSerializable + WKBUnserializable {}
+impl<T> WKBAbleExt for T where T: ?Sized + WKBSerializable + WKBDeserializable {}
 
 impl<T> WKBSerializable for Geometry<T> where T: Into<f64> + Float + Debug
 {
@@ -198,7 +198,7 @@ impl<T> WKBSerializable for Geometry<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for Geometry<f64>
+impl WKBDeserializable for Geometry<f64>
 {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
@@ -217,7 +217,7 @@ impl<T> WKBSerializable for Point<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for Point<f64> {
+impl WKBDeserializable for Point<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -238,7 +238,7 @@ impl<T> WKBSerializable for LineString<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for LineString<f64> {
+impl WKBDeserializable for LineString<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -263,7 +263,7 @@ impl<T> WKBSerializable for Polygon<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for Polygon<f64> {
+impl WKBDeserializable for Polygon<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -286,7 +286,7 @@ impl<T> WKBSerializable for MultiPoint<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for MultiPoint<f64> {
+impl WKBDeserializable for MultiPoint<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -310,7 +310,7 @@ impl<T> WKBSerializable for MultiLineString<T> where T: Into<f64> + Float + Debu
     }
 }
 
-impl WKBUnserializable for MultiLineString<f64> {
+impl WKBDeserializable for MultiLineString<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -334,7 +334,7 @@ impl<T> WKBSerializable for MultiPolygon<T> where T: Into<f64> + Float + Debug
     }
 }
 
-impl WKBUnserializable for MultiPolygon<f64> {
+impl WKBDeserializable for MultiPolygon<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {
@@ -358,7 +358,7 @@ impl<T> WKBSerializable for GeometryCollection<T> where T: Into<f64> + Float + D
     }
 }
 
-impl WKBUnserializable for GeometryCollection<f64> {
+impl WKBDeserializable for GeometryCollection<f64> {
     fn read_from_wkb(r: &mut impl Read) -> Result<Self, WKBReadError>
     {
         match wkb_to_geom(r)? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl From<io::Error> for WKBReadError {
 /// ```
 pub trait WKBSerializable {
     /// Attempt to write self as WKB to a `Write`.
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>;
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>;
 
     /// Return self as WKB bytes
     fn as_wkb_bytes(&self) -> Vec<u8> {
@@ -192,7 +192,7 @@ impl<T> WKBAbleExt for T where T: ?Sized + WKBSerializable + WKBUnserializable {
 
 impl<T> WKBSerializable for Geometry<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         write_geom_to_wkb(self, w)
     }
@@ -209,7 +209,7 @@ impl WKBUnserializable for Geometry<f64>
 impl<T> WKBSerializable for Point<T> where T: Into<f64> + Float + Debug
 {
     #[inline]
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&1_u32.to_le_bytes())?;
@@ -230,7 +230,7 @@ impl WKBUnserializable for Point<f64> {
 impl<T> WKBSerializable for LineString<T> where T: Into<f64> + Float + Debug
 {
     #[inline]
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&2_u32.to_le_bytes())?;
@@ -250,7 +250,7 @@ impl WKBUnserializable for LineString<f64> {
 
 impl<T> WKBSerializable for Polygon<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&(3_u32).to_le_bytes())?;
@@ -275,7 +275,7 @@ impl WKBUnserializable for Polygon<f64> {
 
 impl<T> WKBSerializable for MultiPoint<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&(4_u32).to_le_bytes())?;
@@ -298,7 +298,7 @@ impl WKBUnserializable for MultiPoint<f64> {
 
 impl<T> WKBSerializable for MultiLineString<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&(5_u32).to_le_bytes())?;
@@ -322,7 +322,7 @@ impl WKBUnserializable for MultiLineString<f64> {
 
 impl<T> WKBSerializable for MultiPolygon<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&(6_u32).to_le_bytes())?;
@@ -346,7 +346,7 @@ impl WKBUnserializable for MultiPolygon<f64> {
 
 impl<T> WKBSerializable for GeometryCollection<T> where T: Into<f64> + Float + Debug
 {
-    fn write_as_wkb(&self, w: &mut impl Write) -> Result<(), WKBWriteError>
+    fn write_as_wkb(&self, w: &mut (impl Write + ?Sized)) -> Result<(), WKBWriteError>
     {
         w.write(LITTLE_ENDIAN)?;
         w.write_all(&(7_u32).to_le_bytes())?;
@@ -414,7 +414,7 @@ fn read_point(mut wkb: impl Read) -> Result<Coordinate<f64>, WKBReadError> {
     Ok(Coordinate { x, y })
 }
 
-fn write_point<W: Write, T: Into<f64> + Float + Debug>(
+fn write_point<W: Write + ?Sized, T: Into<f64> + Float + Debug>(
     c: &Coordinate<T>,
     out: &mut W,
 ) -> Result<(), WKBWriteError> {
@@ -433,7 +433,7 @@ fn read_many_points<I: Read>(mut wkb: I) -> Result<Vec<Coordinate<f64>>, WKBRead
     Ok(res)
 }
 
-fn write_many_points<W: Write, T: Into<f64> + Float + Debug>(
+fn write_many_points<W: Write + ?Sized, T: Into<f64> + Float + Debug>(
     mp: &[Coordinate<T>],
     mut out: &mut W,
 ) -> Result<(), WKBWriteError> {


### PR DESCRIPTION
This splits `WKBAbleExt` into two new traits `WKBSerializable` and `WKBUnserializable`, implements `WKBAbleExt` for every type implementing both traits, and implements the new traits for `Geometry`, `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon` and `GeometryCollection`.

With this all supported geometries can be read and written, even when not wrapped in a `Geometry` enum.

Additionally it adds `?Sized` on all `Write` bounds. With this unsized writers are fully supported, without resorting to `&mut &mut R` as previously used in `write_geom_to_wkb` (`mut result: &mut W` combined with `&mut result`).

